### PR TITLE
Add smtp_auth_file.yml & config_options

### DIFF
--- a/jobs/elastalert/spec
+++ b/jobs/elastalert/spec
@@ -7,6 +7,7 @@ templates:
   bin/ctl_utils.sh: bin/ctl_utils.sh
   bin/elastalert-test-rule.sh: bin/elastalert-test-rule.sh
   config/config.yml: config/config.yml
+  config/smtp_auth_file.yml: config/smtp_auth_file.yml
 
 consumes:
 - name: elasticsearch
@@ -42,6 +43,10 @@ properties:
     description: "the retry window for failed alerts."
     default:
       days: 2
+  elastalert.smtp_user:
+    description: "username for smtp authentication."
+  elastalert.smtp_password:
+    description: "password for smtp authentication."
   elastalert.rules:
     description: "List of ElastAlert rules"
     example: |

--- a/jobs/elastalert/spec
+++ b/jobs/elastalert/spec
@@ -43,21 +43,14 @@ properties:
     description: "the retry window for failed alerts."
     default:
       days: 2
-  elastalert.smtp_host:
-    description: "The SMTP host used to send email notifications. This value will be used for email alerts as well, unless overwritten in the rule config."
-    default: "localhost"
-  elastalert.smtp_port:
-    description: "The port to use."
-    default: 25
-  elastalert.from_addr:
-    description: The address to use as the from header in email notifications. This value will be used for email alerts as well, unless overwritten in the rule config."
-    default: "ElastAlert"
   elastalert.smtp_user:
     description: "username for smtp authentication."
     default: ""
   elastalert.smtp_password:
     description: "password for smtp authentication."
     default: ""
+  elastalert.config_options:
+    description: "Additional options to append to config.yml (YAML format)."
   elastalert.rules:
     description: "List of ElastAlert rules"
     example: |

--- a/jobs/elastalert/spec
+++ b/jobs/elastalert/spec
@@ -43,10 +43,21 @@ properties:
     description: "the retry window for failed alerts."
     default:
       days: 2
+  elastalert.smtp_host:
+    description: "The SMTP host used to send email notifications. This value will be used for email alerts as well, unless overwritten in the rule config."
+    default: "localhost"
+  elastalert.smtp_port:
+    description: "The port to use."
+    default: 25
+  elastalert.from_addr:
+    description: The address to use as the from header in email notifications. This value will be used for email alerts as well, unless overwritten in the rule config."
+    default: "ElastAlert"
   elastalert.smtp_user:
     description: "username for smtp authentication."
+    default: ""
   elastalert.smtp_password:
     description: "password for smtp authentication."
+    default: ""
   elastalert.rules:
     description: "List of ElastAlert rules"
     example: |

--- a/jobs/elastalert/templates/config/config.yml
+++ b/jobs/elastalert/templates/config/config.yml
@@ -15,4 +15,4 @@ es_host: <%= elasticsearch_host %>
 es_port: <%= p("elastalert.es_port") %>
 writeback_index: <%= p("elastalert.writeback_index") %>
 <%= YAML.dump(JSON.load(JSON.dump({"alert_time_limit": p("elastalert.alert_time_limit")}))).gsub("---\n", '').strip %>
-
+smtp_auth_file: /var/vcap/jobs/elastalert/config/smtp_auth_file.yaml

--- a/jobs/elastalert/templates/config/config.yml
+++ b/jobs/elastalert/templates/config/config.yml
@@ -15,4 +15,7 @@ es_host: <%= elasticsearch_host %>
 es_port: <%= p("elastalert.es_port") %>
 writeback_index: <%= p("elastalert.writeback_index") %>
 <%= YAML.dump(JSON.load(JSON.dump({"alert_time_limit": p("elastalert.alert_time_limit")}))).gsub("---\n", '').strip %>
-smtp_auth_file: /var/vcap/jobs/elastalert/config/smtp_auth_file.yaml
+smtp_host: <%= p("elastalert.smtp_host") %>
+smtp_port: <%= p("elastalert.smtp_port") %>
+from_addr: <%= p("elastalert.from_addr") %>
+smtp_auth_file: /var/vcap/jobs/elastalert/config/smtp_auth_file.yml

--- a/jobs/elastalert/templates/config/config.yml
+++ b/jobs/elastalert/templates/config/config.yml
@@ -15,7 +15,7 @@ es_host: <%= elasticsearch_host %>
 es_port: <%= p("elastalert.es_port") %>
 writeback_index: <%= p("elastalert.writeback_index") %>
 <%= YAML.dump(JSON.load(JSON.dump({"alert_time_limit": p("elastalert.alert_time_limit")}))).gsub("---\n", '').strip %>
-smtp_host: <%= p("elastalert.smtp_host") %>
-smtp_port: <%= p("elastalert.smtp_port") %>
-from_addr: <%= p("elastalert.from_addr") %>
 smtp_auth_file: /var/vcap/jobs/elastalert/config/smtp_auth_file.yml
+<% if_p('elastalert.config_options') do |config_options| %>
+<%= config_options.to_yaml.gsub(/---/, '') %>
+<% end %>

--- a/jobs/elastalert/templates/config/smtp_auth_file.yml
+++ b/jobs/elastalert/templates/config/smtp_auth_file.yml
@@ -1,2 +1,2 @@
-user: "<%= p(elastalert.smtp_user) %>"
-password: "<%= p(elastalert.smtp_password) %>"
+user: "<%= p('elastalert.smtp_user') %>"
+password: "<%= p('elastalert.smtp_password') %>"

--- a/jobs/elastalert/templates/config/smtp_auth_file.yml
+++ b/jobs/elastalert/templates/config/smtp_auth_file.yml
@@ -1,0 +1,2 @@
+user: "<%= p(elastalert.smtp_user) %>"
+password: "<%= p(elastalert.smtp_password) %>"


### PR DESCRIPTION
`smtp_auth_file.yml` is required for sending email with authentication.
`config_options` is used for general settings such as `from_addr`, `smtp_host`, `smtp_port` and the other.